### PR TITLE
Poccds 109 110 111 112

### DIFF
--- a/src/app/prescription/medication-request-form/dosage-instruction-form/dosage-instruction-form.component.css
+++ b/src/app/prescription/medication-request-form/dosage-instruction-form/dosage-instruction-form.component.css
@@ -1,5 +1,5 @@
 .mat-style-card {
-  padding: 0;
+  padding: 0.2em;
 }
 
 .form-field-row .mat-form-field+.mat-form-field {
@@ -26,7 +26,7 @@ button.mat-stroked-button {
 }
 
 .form-group-title {
-  padding: 15px 0 0 15px;
+  margin: 0 0 0 0.5em;
   font-size: 14px;
   font-weight: 400;
   line-height: 1.125;
@@ -38,7 +38,7 @@ button.mat-stroked-button {
 }
 
 .form-group-body-title {
-  padding: 15px 0 0 15px;
+  padding: 7px 0 0 15px;
   font-weight: 400;
   line-height: 1.125;
   text-decoration: underline;
@@ -57,7 +57,7 @@ button.mat-stroked-button {
 }
 
 /deep/ .form-field-row .dose-and-rate-unit .mat-form-field-infix {
-  width: 50px;
+  width: 70px;
 }
 
 .dosage-instruction-form-title {
@@ -131,4 +131,12 @@ button.mat-stroked-button {
 .mat-expansion-panel-header-description {
   justify-content: space-between;
   align-items: center;
+}
+
+.separator {
+  margin: 1em;
+}
+
+.margin-linked-fields {
+  margin-right: 3em;
 }

--- a/src/app/prescription/medication-request-form/dosage-instruction-form/dosage-instruction-form.component.html
+++ b/src/app/prescription/medication-request-form/dosage-instruction-form/dosage-instruction-form.component.html
@@ -375,12 +375,6 @@
                             [matAutocomplete]="autoUnit" />
                         </mat-form-field>
                         <span class="separator" *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'rate'">par</span>
-                        <mat-form-field appearance="fill" class="dose-and-rate-value"
-                          *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'rate'">
-                          <mat-label> Débit démoninateur </mat-label>
-                          <input type="text" aria-label="débit dénominateur" matInput
-                            [formControl]="toFormControl(dosageInstructionGroup.get(['doseAndRate', 'rateRatio', 'denominator', 'value']))" />
-                        </mat-form-field>
                         <mat-form-field appearance="fill" class="dose-and-rate-unit"
                           *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'rate'">
                           <mat-label> Unité </mat-label>

--- a/src/app/prescription/medication-request-form/dosage-instruction-form/dosage-instruction-form.component.html
+++ b/src/app/prescription/medication-request-form/dosage-instruction-form/dosage-instruction-form.component.html
@@ -147,7 +147,7 @@
                                dosageInstructionGroup.get(['timing', 'repeat', 'boundsMode'])).value === 'duration'"
                                class="small-width-field">
                     <mat-label>
-                      Unité de la durée
+                      Unité
                     </mat-label>
                     <input type="text" aria-label="Unité de la durée de validité de la dose" matInput [formControl]="toFormControl(
                        dosageInstructionGroup.get(['timing', 'repeat', 'boundsDuration', 'unit']))"
@@ -296,7 +296,7 @@
                         </mat-radio-group>
                       </div>
                       <div fxLayout="row" class="form-group-body form-field-row">
-                        <mat-form-field fxFlex="50%" appearance="fill" class="dose-and-rate-value margin-field"
+                        <mat-form-field appearance="fill" class="dose-and-rate-value margin-linked-fields"
                           *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'qt'">
                           <mat-label> Dose </mat-label>
                           <input type="text" aria-label="dose" matInput
@@ -328,15 +328,15 @@
                         </mat-form-field>
                         <mat-card-footer class="dose-error">
                         </mat-card-footer>
-                        <mat-form-field appearance="fill" class="margin-field"
-                          *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'qt'">
-                          <mat-label class="medium-width-field"> Unité </mat-label>
+                        <mat-form-field appearance="fill" 
+                          *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'qt'" class="small-width-field">
+                          <mat-label> Unité </mat-label>
                           <input type="text" aria-label="unité" matInput
                             [formControl]="toFormControl(dosageInstructionGroup.get(['doseAndRate', 'doseQuantity', 'unit']))"
                             [matAutocomplete]="autoUnit" />
                         </mat-form-field>
                         <mat-form-field appearance="fill" *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'time'">
-                          <mat-label class="medium-width-field"> Dose </mat-label>
+                          <mat-label> Dose </mat-label>
                           <input type="text" aria-label="dose" matInput
                             [formControl]="toFormControl(dosageInstructionGroup.get(['doseAndRate', 'rateRatio', 'numerator', 'value']))" />
                         </mat-form-field>
@@ -347,6 +347,7 @@
                             [formControl]="toFormControl(dosageInstructionGroup.get(['doseAndRate', 'rateRatio', 'numerator', 'unit']))"
                             [matAutocomplete]="autoUnit" />
                         </mat-form-field>
+                        <span class="separator" *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'time'">sur</span>
                         <mat-form-field appearance="fill" class="dose-and-rate-value"
                           *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'time'">
                           <mat-label> Durée </mat-label>
@@ -355,7 +356,7 @@
                         </mat-form-field>
                         <mat-form-field appearance="fill" class="dose-and-rate-unit"
                           *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'time'">
-                          <mat-label> Unité </mat-label>
+                          <mat-label class="small-width-field"> Unité </mat-label>
                           <input type="text" aria-label="unité" matInput
                             [formControl]="toFormControl(dosageInstructionGroup.get(['doseAndRate', 'rateRatio', 'denominator', 'unit']))"
                             [matAutocomplete]="autoDurationUnit" />
@@ -373,7 +374,7 @@
                             [formControl]="toFormControl(dosageInstructionGroup.get(['doseAndRate', 'rateRatio', 'numerator', 'unit']))"
                             [matAutocomplete]="autoUnit" />
                         </mat-form-field>
-                        <span *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'rate'">/</span>
+                        <span class="separator" *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'rate'">par</span>
                         <mat-form-field appearance="fill" class="dose-and-rate-value"
                           *ngIf="((doseModes$ | async) ?? [])[nDosage] === 'rate'">
                           <mat-label> Débit démoninateur </mat-label>

--- a/src/app/prescription/medication-request-form/medication-form/medication-form.component.css
+++ b/src/app/prescription/medication-request-form/medication-form/medication-form.component.css
@@ -15,7 +15,7 @@ button.mat-stroked-button {
 }
 
 .form-group-title {
-  padding: 15px 0 0 15px;
+  margin: 0 0 0 0.5em;
   font-weight: 400;
   line-height: 1.125;
 }

--- a/src/app/prescription/medication-request-form/medication-request-form.component.css
+++ b/src/app/prescription/medication-request-form/medication-request-form.component.css
@@ -32,7 +32,6 @@ button.mat-stroked-button {
 }
 
 .form-group-title {
-  padding: 15px 0 0 15px;
   font-weight: 400;
   line-height: 1.125;
 }

--- a/src/app/prescription/medication-request-form/metadata-form/metadata-form.component.css
+++ b/src/app/prescription/medication-request-form/metadata-form/metadata-form.component.css
@@ -5,7 +5,6 @@
 }
 
 .form-group-title {
-  padding: 15px 0 0 15px;
   font-weight: 400;
   line-height: 1.125;
 }

--- a/src/app/prescription/medication-request-form/metadata-form/metadata-form.component.html
+++ b/src/app/prescription/medication-request-form/metadata-form/metadata-form.component.html
@@ -3,7 +3,7 @@
     <mat-expansion-panel-header>
       <mat-panel-title>
         <div class="form-group-title">
-          <span>Contexte clinique</span>
+          <span>Intention de traitement</span>
         </div>
       </mat-panel-title>
       <mat-panel-description>


### PR DESCRIPTION
1 - increase the width of "unit" to be able to display at 15 characters (see 20)

2 - change the text "Clinical context" to "Treatment intention"
center the titles in the fold-out panel

3 - some modifications requested by PO: slight padding on the error fields, alignment, optimization of margins and paddings for decreasing the size of the page...

4 - deletion of the 'denominator flow' field

5 - add the word “on” between the first field “Unit” and the field “Duration”